### PR TITLE
Lock on flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ example configuration:
 ```config
 name=KustoSinkConnector 
 connector.class=com.microsoft.azure.kusto.kafka.connect.sink.KustoSinkConnector 
-kusto.sink.flush_interval_ms=300000 
 key.converter=org.apache.kafka.connect.storage.StringConverter 
 value.converter=org.apache.kafka.connect.storage.StringConverter 
 tasks.max=1 
@@ -61,6 +60,7 @@ kusto.auth.appid=XXX
 kusto.auth.appkey=XXX 
 kusto.sink.tempdir=/var/tmp/ 
 kusto.sink.flush_size=1000
+kusto.sink.flush_interval_ms=300000 
 ```
 Aggregation in the sink is done using files, these are sent to kusto if the aggregated file has reached the flush_size 
 (size is in bytes) or if the flush_interval_ms interval has passed. 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.microsoft.azure</groupId>
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
-    <version>0.4.0</version>
+    <version>0.3.5</version>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.microsoft.azure</groupId>
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
-    <version>0.3.4</version>
+    <version>0.4.0</version>
     <build>
         <plugins>
             <plugin>
@@ -99,11 +99,7 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>${kafka.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>connect-json</artifactId>
-            <version>${kafka.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
@@ -192,7 +192,9 @@ public class FileWriter implements Closeable {
                     flushByTimeImpl();
                 }
             };
-            timer.schedule(t, flushInterval);
+            if(timer != null) {
+                timer.schedule(t, flushInterval);
+            }
         }
     }
 
@@ -212,7 +214,6 @@ public class FileWriter implements Closeable {
             flushError = String.format("Error in flushByTime. Current file: %s, size: %d. ", fileName, currentSize);
             log.error(flushError, e);
         }
-
     }
 
     private class CountingOutputStream extends FilterOutputStream {

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
@@ -1,13 +1,15 @@
 package com.microsoft.azure.kusto.kafka.connect.sink;
 
+import com.google.common.base.Function;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -20,17 +22,19 @@ public class FileWriter implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(KustoSinkTask.class);
     SourceFile currentFile;
     private Timer timer;
-    private Consumer<SourceFile> onRollCallback;
+    private Function<SourceFile, String> onRollCallback;
     private final long flushInterval;
     private final boolean shouldCompressData;
-    private Supplier<String> getFilePath;
+    private Function<Long, String> getFilePath;
     private OutputStream outputStream;
     private String basePath;
     private CountingOutputStream countingStream;
     private long fileThreshold;
-
+    // Lock is given from TopicPartitionWriter to lock while ingesting
+    private ReentrantReadWriteLock reentrantReadWriteLock;
     // Don't remove! File descriptor is kept so that the file is not deleted when stream is closed
     private FileDescriptor currentFileDescriptor;
+    private String flushError;
 
     /**
      * @param basePath       - This is path to which to write the files to.
@@ -41,27 +45,38 @@ public class FileWriter implements Closeable {
      */
     public FileWriter(String basePath,
                       long fileThreshold,
-                      Consumer<SourceFile> onRollCallback,
-                      Supplier<String> getFilePath,
+                      Function<SourceFile, String> onRollCallback,
+                      Function<Long, String> getFilePath,
                       long flushInterval,
-                      boolean shouldCompressData) {
+                      boolean shouldCompressData,
+                      ReentrantReadWriteLock reentrantLock) {
         this.getFilePath = getFilePath;
         this.basePath = basePath;
         this.fileThreshold = fileThreshold;
         this.onRollCallback = onRollCallback;
         this.flushInterval = flushInterval;
         this.shouldCompressData = shouldCompressData;
+
+        // This is a fair lock so that we flush close to the time intervals
+        this.reentrantReadWriteLock = reentrantLock;
+
+        // If we failed on flush we want to throw the error from the put() flow.
+        flushError = null;
+
     }
 
     boolean isDirty() {
         return this.currentFile != null && this.currentFile.rawBytes > 0;
     }
 
-    public synchronized void write(byte[] data) throws IOException {
+    public synchronized void write(byte[] data, @Nullable Long offset) throws IOException {
+        if (flushError != null) {
+            throw new ConnectException(flushError);
+        }
         if (data == null || data.length == 0) return;
 
         if (currentFile == null) {
-            openFile();
+            openFile(offset);
             resetFlushTimer(true);
         }
 
@@ -72,12 +87,12 @@ public class FileWriter implements Closeable {
         currentFile.numRecords++;
 
         if (this.flushInterval == 0 || currentFile.rawBytes > fileThreshold) {
-            rotate();
+            rotate(offset);
             resetFlushTimer(true);
         }
     }
 
-    public void openFile() throws IOException {
+    public void openFile(@Nullable Long offset) throws IOException {
         SourceFile fileProps = new SourceFile();
 
         File folder = new File(basePath);
@@ -85,7 +100,7 @@ public class FileWriter implements Closeable {
             throw new IOException(String.format("Failed to create new directory %s", folder.getPath()));
         }
 
-        String filePath = getFilePath.get();
+        String filePath = getFilePath.apply(offset);
         fileProps.path = filePath;
 
         File file = new File(filePath);
@@ -102,9 +117,9 @@ public class FileWriter implements Closeable {
         currentFile = fileProps;
     }
 
-    void rotate() throws IOException {
+    void rotate(@Nullable Long offset) throws IOException {
         finishFile(true);
-        openFile();
+        openFile(offset);
     }
 
     void finishFile(Boolean delete) throws IOException {
@@ -115,8 +130,10 @@ public class FileWriter implements Closeable {
             } else {
                 outputStream.flush();
             }
-
-            onRollCallback.accept(currentFile);
+            String err = onRollCallback.apply(currentFile);
+            if(err != null){
+                throw new ConnectException(err);
+            }
             if (delete){
                 dumpFile();
             }
@@ -132,6 +149,7 @@ public class FileWriter implements Closeable {
         if (!deleted) {
             log.warn("couldn't delete temporary file. File exists: " + currentFile.file.exists());
         }
+        currentFile = null;
     }
 
     public void rollback() throws IOException {
@@ -178,18 +196,23 @@ public class FileWriter implements Closeable {
         }
     }
 
-    private void flushByTimeImpl() {
+    void flushByTimeImpl() {
         try {
+            // Flush time interval gets the write lock so that it won't starve
+            reentrantReadWriteLock.writeLock().lock();
+            // Lock before the check so that if a writing process just flushed this won't ingest empty files
             if (currentFile != null && currentFile.rawBytes > 0) {
-                rotate();
+                finishFile(true);
             }
+            reentrantReadWriteLock.writeLock().unlock();
+            resetFlushTimer(false);
         } catch (Exception e) {
             String fileName = currentFile == null ? "no file created yet" : currentFile.file.getName();
             long currentSize = currentFile == null ? 0 : currentFile.rawBytes;
-            log.error(String.format("Error in flushByTime. Current file: %s, size: %d. ", fileName, currentSize), e);
+            flushError = String.format("Error in flushByTime. Current file: %s, size: %d. ", fileName, currentSize);
+            log.error(flushError, e);
         }
 
-        resetFlushTimer(false);
     }
 
     private class CountingOutputStream extends FilterOutputStream {

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkConfig.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkConfig.java
@@ -26,6 +26,8 @@ public class KustoSinkConfig extends AbstractConfig {
     static final String KUSTO_SINK_FLUSH_SIZE = "kusto.sink.flush_size";
     static final String KUSTO_SINK_FLUSH_INTERVAL_MS = "kusto.sink.flush_interval_ms";
     static final String KUSTO_SINK_WRITE_TO_FILES = "kusto.sink.write_to_files";
+    static final String KUSTO_COMMIT_IMMEDIATLY = "kusto.sink.commit";
+    static final String KUSTO_RETRIES_COUNT = "kusto.sink.retries";
 
     public KustoSinkConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
@@ -46,7 +48,9 @@ public class KustoSinkConfig extends AbstractConfig {
                 .define(KUSTO_AUTH_AUTHORITY, Type.STRING, null, Importance.HIGH, "Kusto auth using appid,appkey combo: authority")
                 .define(KUSTO_SINK_TEMPDIR, Type.STRING, System.getProperty("java.io.tempdir"), Importance.LOW, "Temp dir that will be used by kusto sink to buffer records. defaults to system temp dir")
                 .define(KUSTO_SINK_FLUSH_SIZE, Type.LONG, FileUtils.ONE_MB, Importance.HIGH, "Kusto sink max buffer size (per topic+partition combo)")
-                .define(KUSTO_SINK_FLUSH_INTERVAL_MS, Type.LONG, TimeUnit.MINUTES.toMillis(5), Importance.HIGH, "Kusto sink max staleness in milliseconds (per topic+partition combo)");
+                .define(KUSTO_SINK_FLUSH_INTERVAL_MS, Type.LONG, TimeUnit.MINUTES.toMillis(5), Importance.HIGH, "Kusto sink max staleness in milliseconds (per topic+partition combo)")
+                .define(KUSTO_COMMIT_IMMEDIATLY, Type.BOOLEAN, false, Importance.LOW, "Weather kafka call to commit offsets will flush and commit the last offsets or only the ingested ones")
+                .define(KUSTO_RETRIES_COUNT, Type.INT, 2, Importance.LOW, "Number of retries on ingestions before throwing");
     }
 
     public String getKustoUrl() {
@@ -88,5 +92,13 @@ public class KustoSinkConfig extends AbstractConfig {
     public long getKustoFlushIntervalMS() {
         return this.getLong(KUSTO_SINK_FLUSH_INTERVAL_MS);
     }
+
+    public boolean getKustoCommitImmediatly() {
+        return this.getBoolean(KUSTO_COMMIT_IMMEDIATLY);
+    }
+    public int getKustoRetriesCount() {
+        return this.getInt(KUSTO_RETRIES_COUNT);
+    }
+
 }
 

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
@@ -276,7 +276,7 @@ public class KustoSinkTask extends SinkTask {
                 Long offset = writers.get(tp).lastCommittedOffset;
 
                 if (offset != null) {
-                    log.debug("Forwarding to framework request to commit offset: {} for {}", offset, tp);
+                    log.debug("Forwarding to framework request to commit offset: {} for {} while the offset is {}", offset, tp, offsets.get(tp));
                     offsetsToCommit.put(tp, new OffsetAndMetadata(offset));
                 }
             }

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
@@ -18,9 +18,12 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Kusto sink uses file system to buffer records.
@@ -36,6 +39,8 @@ public class KustoSinkTask extends SinkTask {
     private long maxFileSize;
     private long flushInterval;
     private String tempDir;
+    private boolean commitImmediately;
+    private int retiresCount;
 
     public KustoSinkTask() {
         assignment = new HashSet<>();
@@ -95,7 +100,7 @@ public class KustoSinkTask extends SinkTask {
                         IngestionProperties props = new IngestionProperties(db, table);
 
                         if (format != null && !format.isEmpty()) {
-                            if (format.equals("json") || format.equals("singlejson")){
+                            if (format.equals("json") || format.equals("singlejson") || format.equalsIgnoreCase("multijson")){
                                 props.setDataFormat("multijson");
                             }
                             props.setDataFormat(format);
@@ -155,7 +160,7 @@ public class KustoSinkTask extends SinkTask {
             if (ingestionProps == null) {
                 throw new ConnectException(String.format("Kusto Sink has no ingestion props mapped for the topic: %s. please check your configuration.", tp.topic()));
             } else {
-                TopicPartitionWriter writer = new TopicPartitionWriter(tp, kustoIngestClient, ingestionProps, tempDir, maxFileSize, flushInterval);
+                TopicPartitionWriter writer = new TopicPartitionWriter(tp, kustoIngestClient, ingestionProps, tempDir, maxFileSize, flushInterval, commitImmediately, retiresCount);
 
                 writer.open();
                 writers.put(tp, writer);
@@ -165,6 +170,7 @@ public class KustoSinkTask extends SinkTask {
 
     @Override
     public void close(Collection<TopicPartition> partitions) {
+        log.warn("KustoConnector got a request to close sink task");
         for (TopicPartition tp : partitions) {
             try {
                 writers.get(tp).close();
@@ -184,11 +190,12 @@ public class KustoSinkTask extends SinkTask {
             String url = config.getKustoUrl();
 
             topicsToIngestionProps = getTopicsToIngestionProps(config);
-            // this should be read properly from settings
             kustoIngestClient = createKustoIngestClient(config);
             tempDir = config.getKustoSinkTempDir();
             maxFileSize = config.getKustoFlushSize();
             flushInterval = config.getKustoFlushIntervalMS();
+            commitImmediately = config.getKustoCommitImmediatly();
+            retiresCount = config.getKustoRetriesCount();
             log.info(String.format("Kafka Kusto Sink started. target cluster: (%s), source topics: (%s)", url, topicsToIngestionProps.keySet().toString()));
             open(context.assignment());
 
@@ -214,9 +221,16 @@ public class KustoSinkTask extends SinkTask {
 
     @Override
     public void put(Collection<SinkRecord> records) throws ConnectException {
+        log.debug("put '"+ records.size() + "' num of records");
+        int i = 0;
+        SinkRecord lastRecord = null;
         for (SinkRecord record : records) {
-            log.debug("record to topic:" + record.topic());
-
+            if (i == 0) {
+                log.debug("First record is to topic:" + record.topic());
+                log.debug("First record offset:" + record.kafkaOffset());
+            }
+            lastRecord = record;
+            i++;
             TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
             TopicPartitionWriter writer = writers.get(tp);
 
@@ -228,6 +242,11 @@ public class KustoSinkTask extends SinkTask {
 
             writer.writeRecord(record);
         }
+
+        if (lastRecord != null) {
+            log.debug("Last record was for topic:" + lastRecord.topic());
+            log.debug("Last record had offset:" + lastRecord.kafkaOffset());
+        }
     }
 
     // This is a neat trick, since our rolling files commit whenever they like, offsets may drift
@@ -236,23 +255,38 @@ public class KustoSinkTask extends SinkTask {
     public Map<TopicPartition, OffsetAndMetadata> preCommit(
             Map<TopicPartition, OffsetAndMetadata> offsets
     ) {
+        log.info("preCommit called and sink is configured to " + (commitImmediately ? "flush and commit immediatly": "commit only successfully sent for ingestion offsets"));
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = new HashMap<>();
-        for (TopicPartition tp : assignment) {
+        if (commitImmediately) {
+            CompletableFuture[] tasks = new CompletableFuture[assignment.size()];
+            int i = 0;
+            for (TopicPartition tp : assignment) {
+                TopicPartitionWriter topicPartitionWriter = writers.get(tp);
+                tasks[i] = (CompletableFuture.runAsync(() -> topicPartitionWriter.fileWriter.flushByTimeImpl()));
+            }
+            CompletableFuture<Void> voidCompletableFuture = CompletableFuture.allOf(tasks);
+            try {
+                voidCompletableFuture.get(4L, TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                log.warn("failed to flush some of the partition writers in 4 seconds before comitting");
+            }
+        } else {
+            for (TopicPartition tp : assignment) {
 
-            Long offset = writers.get(tp).lastCommittedOffset;
+                Long offset = writers.get(tp).lastCommittedOffset;
 
-            if (offset != null) {
-                log.debug("Forwarding to framework request to commit offset: {} for {}", offset, tp);
-                offsetsToCommit.put(tp, new OffsetAndMetadata(offset));
+                if (offset != null) {
+                    log.debug("Forwarding to framework request to commit offset: {} for {}", offset, tp);
+                    offsetsToCommit.put(tp, new OffsetAndMetadata(offset));
+                }
             }
         }
 
-        return offsetsToCommit;
+        return commitImmediately ? offsets : offsetsToCommit;
     }
 
     @Override
     public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) throws ConnectException {
         // do nothing , rolling files can handle writing
-
     }
 }

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
@@ -7,15 +7,19 @@ import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public class TopicPartitionWriter {
+class TopicPartitionWriter {
     private static final Logger log = LoggerFactory.getLogger(KustoSinkTask.class);
     private final CompressionType eventDataCompression;
     private final TopicPartition tp;
@@ -23,38 +27,67 @@ public class TopicPartitionWriter {
     private final IngestionProperties ingestionProps;
     private final String basePath;
     private final long flushInterval;
+    private boolean commitImmediately;
     private final long fileThreshold;
-
     FileWriter fileWriter;
     long currentOffset;
     Long lastCommittedOffset;
+    private int defaultRetriesCount;
+    private int currentRetries;
+    private ReentrantReadWriteLock reentrantReadWriteLock;
 
-    TopicPartitionWriter(TopicPartition tp, IngestClient client, TopicIngestionProperties ingestionProps, String basePath, long fileThreshold, long flushInterval) {
+    TopicPartitionWriter(TopicPartition tp, IngestClient client, TopicIngestionProperties ingestionProps, String basePath,
+                         long fileThreshold, long flushInterval, boolean commitImmediatly, int retriesCount) {
         this.tp = tp;
         this.client = client;
         this.ingestionProps = ingestionProps.ingestionProperties;
         this.fileThreshold = fileThreshold;
         this.basePath = basePath;
         this.flushInterval = flushInterval;
+        this.commitImmediately = commitImmediatly;
         this.currentOffset = 0;
         this.eventDataCompression = ingestionProps.eventDataCompression;
+        this.defaultRetriesCount = retriesCount;
+        this.currentRetries = retriesCount;
+        this.reentrantReadWriteLock = new ReentrantReadWriteLock(true);
     }
 
-    public void handleRollFile(SourceFile fileDescriptor) {
+    String handleRollFile(SourceFile fileDescriptor) {
         FileSourceInfo fileSourceInfo = new FileSourceInfo(fileDescriptor.path, fileDescriptor.rawBytes);
-
+        new ArrayList<>();
         try {
             client.ingestFromFile(fileSourceInfo, ingestionProps);
 
             log.info(String.format("Kusto ingestion: file (%s) of size (%s) at current offset (%s)", fileDescriptor.path, fileDescriptor.rawBytes, currentOffset));
             this.lastCommittedOffset = currentOffset;
+            currentRetries = defaultRetriesCount;
         } catch (Exception e) {
             log.error("Ingestion Failed for file : "+ fileDescriptor.file.getName() + ", message: " + e.getMessage() + "\nException  : " + ExceptionUtils.getStackTrace(e));
+            if (commitImmediately) {
+                if (currentRetries > 0) {
+                    try {
+                        // Default time for commit is 5 seconds timeout.
+                        Thread.sleep(1500);
+                    } catch (InterruptedException e1) {
+                        log.error("Couldn't sleep !");
+                    }
+                    log.error("Ingestion Failed for file : " + fileDescriptor.file.getName() + ", defaultRetriesCount left '" + defaultRetriesCount + "'. message: " + e.getMessage() + "\nException  : " + ExceptionUtils.getStackTrace(e));
+                    currentRetries--;
+                    return handleRollFile(fileDescriptor);
+                } else {
+                  // Returning string will make the caller throw
+                  return "Ingestion Failed for file : " + fileDescriptor.file.getName() + ", defaultRetriesCount left '" + defaultRetriesCount + "'. message: " + e.getMessage() + "\nException  : " + ExceptionUtils.getStackTrace(e);
+                }
+            }
         }
+
+        return null;
     }
 
-    public String getFilePath() {
-        long nextOffset = fileWriter != null && fileWriter.isDirty() ? currentOffset + 1 : currentOffset;
+    String getFilePath(@Nullable Long offset) {
+        // Should be null if flushed by interval
+        offset = offset == null ? currentOffset : offset;
+        long nextOffset = fileWriter != null && fileWriter.isDirty() ? offset + 1 : offset;
 
         String compressionExtension = "";
         if (shouldCompressData(ingestionProps, null) || eventDataCompression != null) {
@@ -68,7 +101,7 @@ public class TopicPartitionWriter {
         return Paths.get(basePath, String.format("kafka_%s_%s_%d.%s%s", tp.topic(), tp.partition(), nextOffset, ingestionProps.getDataFormat(), compressionExtension)).toString();
     }
 
-    public void writeRecord(SinkRecord record) {
+    void writeRecord(SinkRecord record) throws ConnectException {
         byte[] value = null;
 
         // TODO: should probably refactor this code out into a value transformer
@@ -86,20 +119,24 @@ public class TopicPartitionWriter {
         } else {
             log.error(String.format("Unexpected value type, skipping record %s", record));
         }
-
         if (value == null) {
             this.currentOffset = record.kafkaOffset();
         } else {
             try {
+                reentrantReadWriteLock.readLock().lock();
+
+                // Current offset is saved after flushing for the flush timer to use
+                fileWriter.write(value, record.kafkaOffset());
                 this.currentOffset = record.kafkaOffset();
-                fileWriter.write(value);
-            } catch (IOException e) {
-                log.error("File write failed", e);
+            } catch (IOException ex){
+                throw new org.apache.kafka.connect.errors.ConnectException("Got an IOExcption while writing to file with message:" + ex.getMessage());
+            } finally {
+                reentrantReadWriteLock.readLock().unlock();
             }
         }
     }
 
-    public void open() {
+    void open() {
         // Should compress binary files
         boolean shouldCompressData = shouldCompressData(this.ingestionProps, this.eventDataCompression);
 
@@ -109,10 +146,11 @@ public class TopicPartitionWriter {
                 this::handleRollFile,
                 this::getFilePath,
                 !shouldCompressData ? 0 : flushInterval,
-                shouldCompressData);
+                shouldCompressData,
+                reentrantReadWriteLock);
     }
 
-    public void close() {
+    void close() {
         try {
             fileWriter.rollback();
             // fileWriter.close(); TODO ?

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/E2ETest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/E2ETest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Assertions;
 import org.testng.Assert;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
@@ -40,7 +39,7 @@ public class E2ETest {
     private Logger log = Logger.getLogger(this.getClass().getName());
 
     @Test
-//    @Ignore
+    @Ignore
     public void testE2ECsv() throws URISyntaxException, DataClientException, DataServiceException {
         String table = tableBaseName + "csv";
         ConnectionStringBuilder engineCsb = ConnectionStringBuilder.createWithAadApplicationCredentials(String.format("https://%s.kusto.windows.net", cluster), appId, appKey, authority);
@@ -94,7 +93,7 @@ public class E2ETest {
     }
 
     @Test
-//    @Ignore
+    @Ignore
     public void testE2EAvro() throws URISyntaxException, DataClientException, DataServiceException {
         String table = tableBaseName + "avro";
         ConnectionStringBuilder engineCsb = ConnectionStringBuilder.createWithAadApplicationCredentials(String.format("https://%s.kusto.windows.net", cluster), appId, appKey, authority);

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/E2ETest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/E2ETest.java
@@ -26,6 +26,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 public class E2ETest {
     private static final String testPrefix = "tmpKafkaE2ETest";
@@ -36,9 +37,10 @@ public class E2ETest {
     private String database = System.getProperty("database");
     private String tableBaseName = System.getProperty("table", testPrefix + UUID.randomUUID().toString().replace('-', '_'));
     private String basePath = Paths.get("src/test/resources/", "testE2E").toString();
+    private Logger log = Logger.getLogger(this.getClass().getName());
 
     @Test
-    @Ignore
+//    @Ignore
     public void testE2ECsv() throws URISyntaxException, DataClientException, DataServiceException {
         String table = tableBaseName + "csv";
         ConnectionStringBuilder engineCsb = ConnectionStringBuilder.createWithAadApplicationCredentials(String.format("https://%s.kusto.windows.net", cluster), appId, appKey, authority);
@@ -69,7 +71,7 @@ public class E2ETest {
             props.ingestionProperties.setDataFormat(IngestionProperties.DATA_FORMAT.csv);
             props.ingestionProperties.setIngestionMapping("mappy", IngestionMapping.IngestionMappingKind.csv);
 
-            TopicPartitionWriter writer = new TopicPartitionWriter(tp, ingestClient, props, Paths.get(basePath, "csv").toString(), fileThreshold, flushInterval);
+            TopicPartitionWriter writer = new TopicPartitionWriter(tp, ingestClient, props, Paths.get(basePath, "csv").toString(), fileThreshold, flushInterval, false, 0);
             writer.open();
 
             List<SinkRecord> records = new ArrayList<SinkRecord>();
@@ -92,7 +94,7 @@ public class E2ETest {
     }
 
     @Test
-    @Ignore
+//    @Ignore
     public void testE2EAvro() throws URISyntaxException, DataClientException, DataServiceException {
         String table = tableBaseName + "avro";
         ConnectionStringBuilder engineCsb = ConnectionStringBuilder.createWithAadApplicationCredentials(String.format("https://%s.kusto.windows.net", cluster), appId, appKey, authority);
@@ -117,7 +119,7 @@ public class E2ETest {
             props2.ingestionProperties.setDataFormat(IngestionProperties.DATA_FORMAT.avro);
             props2.ingestionProperties.setIngestionMapping("avri", IngestionMapping.IngestionMappingKind.avro);
             TopicPartition tp2 = new TopicPartition("testPartition2", 11);
-            TopicPartitionWriter writer2 = new TopicPartitionWriter(tp2, ingestClient, props2, Paths.get(basePath, "avro").toString(), 10, 300000);
+            TopicPartitionWriter writer2 = new TopicPartitionWriter(tp2, ingestClient, props2, Paths.get(basePath, "avro").toString(), 10, 300000, false, 0);
             writer2.open();
             List<SinkRecord> records2 = new ArrayList<SinkRecord>();
 
@@ -157,5 +159,6 @@ public class E2ETest {
             timeElapsedMs += sleepPeriodMs;
         }
         Assertions.assertEquals(res.getValues().get(0).get(0), expectedNumberOfRows.toString());
+        this.log.info("Succesfully ingested " + expectedNumberOfRows + " records.");
     }
 }

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriterTest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriterTest.java
@@ -1,5 +1,6 @@
 package com.microsoft.azure.kusto.kafka.connect.sink;
 
+import com.google.common.base.Function;
 import com.microsoft.azure.kusto.ingest.IngestClient;
 import com.microsoft.azure.kusto.ingest.IngestionProperties;
 import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
@@ -59,7 +60,7 @@ public class TopicPartitionWriterTest {
         IngestionProperties ingestionProperties = new IngestionProperties(db, table);
         TopicIngestionProperties props = new TopicIngestionProperties();
         props.ingestionProperties = ingestionProperties;
-        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockedClient, props, basePath, fileThreshold, flushInterval);
+        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockedClient, props, basePath, fileThreshold, flushInterval, false, 0);
 
         SourceFile descriptor = new SourceFile();
         descriptor.rawBytes = 1024;
@@ -94,9 +95,9 @@ public class TopicPartitionWriterTest {
 
         props.ingestionProperties = new IngestionProperties(db, table);
         props.ingestionProperties.setDataFormat(IngestionProperties.DATA_FORMAT.csv);
-        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval);
+        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval, false, 0);
 
-        Assert.assertEquals(writer.getFilePath(), Paths.get(basePath, "kafka_testTopic_11_0.csv.gz").toString());
+        Assert.assertEquals(writer.getFilePath(null), Paths.get(basePath, "kafka_testTopic_11_0.csv.gz").toString());
     }
 
     @Test
@@ -111,7 +112,7 @@ public class TopicPartitionWriterTest {
         TopicIngestionProperties props = new TopicIngestionProperties();
         props.ingestionProperties = new IngestionProperties(db, table);
         props.ingestionProperties.setDataFormat(IngestionProperties.DATA_FORMAT.csv);
-        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval);
+        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval, false, 0);
         writer.open();
         List<SinkRecord> records = new ArrayList<>();
 
@@ -122,7 +123,7 @@ public class TopicPartitionWriterTest {
             writer.writeRecord(record);
         }
 
-        Assert.assertEquals(writer.getFilePath(), Paths.get(basePath, "kafka_testTopic_11_5.csv.gz").toString());
+        Assert.assertEquals(writer.getFilePath(null), Paths.get(basePath, "kafka_testTopic_11_5.csv.gz").toString());
     }
 
     @Test
@@ -137,7 +138,7 @@ public class TopicPartitionWriterTest {
         TopicIngestionProperties props = new TopicIngestionProperties();
         props.ingestionProperties = new IngestionProperties(db, table);
         props.ingestionProperties.setDataFormat(IngestionProperties.DATA_FORMAT.csv);
-        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval);
+        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval, false, 0);
         writer.open();
         writer.close();
     }
@@ -181,7 +182,7 @@ public class TopicPartitionWriterTest {
 
         props.ingestionProperties = new IngestionProperties(db, table);
         props.ingestionProperties.setDataFormat(IngestionProperties.DATA_FORMAT.csv);
-        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval);
+        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval, false, 0);
 
 
         writer.open();
@@ -213,7 +214,7 @@ public class TopicPartitionWriterTest {
         TopicIngestionProperties props = new TopicIngestionProperties();
         props.ingestionProperties = new IngestionProperties(db, table);
         props.ingestionProperties.setDataFormat(IngestionProperties.DATA_FORMAT.csv);
-        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval);
+        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval, false, 0);
 
         writer.open();
         List<SinkRecord> records = new ArrayList<SinkRecord>();
@@ -235,8 +236,8 @@ public class TopicPartitionWriterTest {
 
         // Read
         writer.fileWriter.finishFile(false);
-        Consumer<SourceFile> assertFileConsumer = FileWriterTest.getAssertFileConsumer(messages[2] + "\n");
-        assertFileConsumer.accept(writer.fileWriter.currentFile);
+        Function<SourceFile, String> assertFileConsumer = FileWriterTest.getAssertFileConsumer(messages[2] + "\n");
+        assertFileConsumer.apply(writer.fileWriter.currentFile);
         writer.close();
     }
 
@@ -261,7 +262,7 @@ public class TopicPartitionWriterTest {
         TopicIngestionProperties props = new TopicIngestionProperties();
         props.ingestionProperties = new IngestionProperties(db, table);
         props.ingestionProperties.setDataFormat(IngestionProperties.DATA_FORMAT.avro);
-        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval);
+        TopicPartitionWriter writer = new TopicPartitionWriter(tp, mockClient, props, basePath, fileThreshold, flushInterval, false, 0);
 
         writer.open();
         List<SinkRecord> records = new ArrayList<SinkRecord>();


### PR DESCRIPTION
#### Pull Request Description

Locking over the flush by time timer

---

#### Future Release Comment
**Features:**
- Retries can be configured
- Can select mode of commit immediately which bypass the current offset dealing by ignoring our lastCommitedOffset. Also will trigger flushes over the writers from preCommit flow.

**Fixes:**
 - locking writing and ingesting so that ingest by flush won't try to ingest while an ingest is ongoing