### PR TITLE
Precommit offset fix

### DIFF
--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkConfig.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkConfig.java
@@ -201,7 +201,7 @@ public class KustoSinkConfig extends AbstractConfig {
             .define(
                 KUSTO_SINK_TEMP_DIR_CONF,
                 Type.STRING,
-                System.getProperty("java.io.tempdir"),
+                System.getProperty("java.io.tmpdir"),
                 Importance.LOW,
                 KUSTO_SINK_TEMP_DIR_DOC,
                 writeGroupName,
@@ -324,23 +324,23 @@ public class KustoSinkConfig extends AbstractConfig {
     }
 
     public String getErrorTolerance() {
-        return this.getString(KUSTO_SINK_TEMP_DIR_CONF);
+        return this.getString(KUSTO_SINK_ERROR_TOLERANCE_CONF);
     }
 
     public String getDlqBootstrapServers() {
-        return this.getString(KUSTO_SINK_TEMP_DIR_CONF);
+        return this.getString(KUSTO_DLQ_BOOTSTRAP_SERVERS_CONF);
     }
 
     public String getDlqTopicName() {
-        return this.getString(KUSTO_SINK_TEMP_DIR_CONF);
+        return this.getString(KUSTO_DLQ_TOPIC_NAME_CONF);
     }
 
     public long getMaxRetryTime() {
-        return this.getLong(KUSTO_SINK_FLUSH_SIZE_BYTES_CONF);
+        return this.getLong(KUSTO_SINK_MAX_RETRY_TIME_MS_CONF);
     }
 
     public long getBackOffTime() {
-        return this.getLong(KUSTO_SINK_FLUSH_SIZE_BYTES_CONF);
+        return this.getLong(KUSTO_SINK_RETRY_BACKOFF_TIME_MS_CONF);
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
@@ -247,7 +247,7 @@ public class KustoSinkTask extends SinkTask {
         Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = new HashMap<>();
         for (TopicPartition tp : assignment) {
 
-            Long offset = writers.get(tp).lastCommittedOffset;
+            Long offset = writers.get(tp).lastCommittedOffset + 1;
 
             if (offset != null) {
                 log.debug("Forwarding to framework request to commit offset: {} for {} while the offset is {}", offset, tp, offsets.get(tp));


### PR DESCRIPTION
This fix should actually be introduced in Kafka Connect framework.
The following causes a single duplicate record(last committed) to be processed in case of restarts and rebalances.