### PR TITLE
Cast the count of records to long instead of int

### DIFF
--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
@@ -252,7 +252,7 @@ public class KustoSinkTask extends SinkTask {
         try {
             try {
                 KustoOperationResult rs = engineClient.execute(database, String.format(FETCH_TABLE_QUERY, table));
-                if ((int) rs.getPrimaryResults().getData().get(0).get(0) >= 0) {
+                if ((long) rs.getPrimaryResults().getData().get(0).get(0) >= 0) {
                     hasAccess = true;
                 }
 


### PR DESCRIPTION
#### Pull Request Description

If there are too many records in the table to fit in an int, this cast will throw an exception.

However, a more performant fix would be to instead execute a more trivial query, and will be done in the future.

---

#### Future Release Comment
**Fixes:**
- Fix casting of count of records to long instead of int, to accommodate larger databases.