### PR TITLE
Upgrade pom version in order to release with fix to Issue 41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
     <description>A Kafka Connect plugin for Azure Data Explorer (Kusto) Database</description>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <properties>
         <kafka.version>1.0.0</kafka.version>
         <json.version>20090211</json.version>


### PR DESCRIPTION
#### Pull Request Description

If there are too many records in the table to fit in an int, this cast will throw an exception. Cast to long instead to prevent this issue.

However, a more performant fix would be to instead execute a more trivial query, and will be done in the future.

---

#### Future Release Comment
**Fixes:**
- Fix casting of count of records to long instead of int, to accommodate larger databases.