### PR TITLE
Upgraded JUnit from 4.7 to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <kafka.version>1.0.0</kafka.version>
         <json.version>20090211</json.version>
+        <junit.version>4.13.1</junit.version>
         <commonio.version>2.6</commonio.version>
         <kusto-sdk.version>2.1.0</kusto-sdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -148,10 +149,11 @@
             <artifactId>commons-io</artifactId>
             <version>${commonio.version}</version>
         </dependency>
+        <!-- TODO: We're using both JUnit4 and JUnit 5 (see next dependency). Remove JUnit 4. -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.7</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
#### Pull Request Description

Upgrading to JUnit 4.13.1 even though we're not affected by this vulnerability for the following reasons:
1)	This is for junit, which is not delivered anyway (pom test scope)
2)	We don't use any Rules, nevermind the vulnerable Rule "TemporaryFolder"
3)	We never execute this in a place where there are both:
a.	Sensitive data in a TemporaryFolder, and
b.	Untrusted users


---

#### Future Release Comment
Upgraded JUnit from 4.7 to 4.13.1

**Fixes:**
- Fixes potential software vulnerability, though it isn't relevant to this code.
