### PR TITLE
Bump the version to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
     <description>A Kafka Connect plugin for Azure Data Explorer (Kusto) Database</description>
-    <version>1.0.4</version>
+    <version>2.0.0</version>
     <properties>
         <kafka.version>1.0.0</kafka.version>
         <json.version>20090211</json.version>


### PR DESCRIPTION
#### Pull Request Description

Bump the version to 2.0.0 because of the new required kusto.query.url parameter and renaming of the kusto.url parameter to kusto.ingestion.url.

---

#### Future Release Comment
Bump the version to 2.0.0 because of the new required kusto.query.url parameter and renaming of the kusto.url parameter to kusto.ingestion.url.

**Breaking Changes:**
- New required kusto.query.url parameter
- Existing kusto.url parameter renamed to kusto.ingestion.url

**Fixes:**
- Can now specify a Kusto Query URL that isn't simply the default of the Kusto Ingestion URL prepended with "ingest-".