### PR TITLE
Refactoring to ensure timers are cancelled after topic partitions are closed

### DIFF
--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
@@ -146,7 +146,7 @@ public class FileWriter implements Closeable {
             if (delete){
                 dumpFile();
             }
-        } else {
+        } else if (outputStream != null) {
             outputStream.close();
         }
     }
@@ -169,15 +169,6 @@ public class FileWriter implements Closeable {
             log.warn("couldn't delete temporary file. File exists: " + currentFile.file.exists());
         }
         currentFile = null;
-    }
-
-    public void rollback() throws IOException {
-        if (countingStream != null) {
-            countingStream.close();
-            if (currentFile != null && currentFile.file != null) {
-                dumpFile();
-            }
-        }
     }
 
     public void close() throws IOException, DataException {

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
@@ -244,8 +244,7 @@ class TopicPartitionWriter {
 
     void close() {
         try {
-            fileWriter.rollback();
-            // fileWriter.close(); TODO ?
+            fileWriter.close();
         } catch (IOException e) {
             log.error("Failed to rollback with exception={}", e);
         }

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriterTest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriterTest.java
@@ -73,7 +73,6 @@ public class FileWriterTest {
         Assertions.assertEquals(FILE_PATH, fileWriter.currentFile.path);
         Assertions.assertTrue(fileWriter.currentFile.file.canWrite());
 
-        fileWriter.rollback();
     }
 
     @Test


### PR DESCRIPTION
#### Pull Request Description
Addresses: https://github.com/Azure/kafka-sink-azure-kusto/issues/64

I believe the `rollback()` method is no longer useful in any context so I've removed it as well.
The null check for the outputStream was added to prevent NPEs in tests.

---

#### Future Release Comment
Fixed a defect that prevented timer threads from closing for TopicPartitions that were closed for a task instance.

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- https://github.com/Azure/kafka-sink-azure-kusto/issues/64
