### PR TITLE
Wait on close

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
     <description>A Kafka Connect plugin for Azure Data Explorer (Kusto) Database</description>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <properties>
         <kafka.version>1.0.0</kafka.version>
         <json.version>20090211</json.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
     <description>A Kafka Connect plugin for Azure Data Explorer (Kusto) Database</description>
-    <version>2.3.1</version>
+    <version>3.0.1</version>
     <properties>
         <kafka.version>1.0.0</kafka.version>
         <json.version>20090211</json.version>
@@ -180,7 +180,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
-            <version>5.2.1</version>
+            <version>7.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
@@ -190,14 +190,12 @@ public class FileWriter implements Closeable {
         }
     }
 
-    public void close() throws IOException, DataException {
+    @Override
+    public void close() throws IOException {
         stop();
-
-        // Flush last file, updating index
-        finishFile(true);
     }
 
-    public void stop() {
+    public void stop() throws DataException {
         stopped = true;
 
         if (timer != null) {
@@ -243,7 +241,6 @@ public class FileWriter implements Closeable {
             }
 
             resetFlushTimer(false);
-            reentrantReadWriteLock.writeLock().unlock();
         } catch (Exception e) {
             String fileName = currentFile == null ? "no file created yet" : currentFile.file.getName();
             long currentSize = currentFile == null ? 0 : currentFile.rawBytes;

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
@@ -173,13 +173,13 @@ public class FileWriter implements Closeable {
     private void dumpFile() throws IOException {
         SourceFile temp = this.currentFile;
         if (temp != null) {
+            this.currentFile = null;
             countingStream.close();
             currentFileDescriptor = null;
             boolean deleted = temp.file.delete();
             if (!deleted) {
                 log.warn("couldn't delete temporary file. File exists: " + temp.file.exists());
             }
-            this.currentFile = null;
         }
     }
 
@@ -236,6 +236,10 @@ public class FileWriter implements Closeable {
         try {
             // Flush time interval gets the write lock so that it won't starve
             reentrantReadWriteLock.writeLock().lock();
+
+            if (stopped) {
+                return;
+            }
 
             // Lock before the check so that if a writing process just flushed this won't ingest empty files
             if (isDirty()) {

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriter.java
@@ -181,7 +181,7 @@ public class FileWriter implements Closeable {
         }
     }
 
-    public void rollback() throws IOException {
+    public synchronized void rollback() throws IOException {
         if (countingStream != null) {
             countingStream.close();
             if (currentFile != null && currentFile.file != null) {
@@ -191,11 +191,11 @@ public class FileWriter implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         stop();
     }
 
-    public void stop() throws DataException {
+    public synchronized void stop() throws DataException {
         stopped = true;
 
         if (timer != null) {

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
@@ -404,6 +404,11 @@ public class KustoSinkTask extends SinkTask {
     @Override
     public void stop() {
         log.warn("Stopping KustoSinkTask");
+        // First stop so that no more ingestions trigger from timer flushes
+        for (TopicPartitionWriter writer : writers.values()) {
+            writer.stop();
+        }
+
         for (TopicPartitionWriter writer : writers.values()) {
             writer.close();
         }

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
@@ -240,7 +240,7 @@ class TopicPartitionWriter {
     void close() {
         try {
             fileWriter.rollback();
-            // fileWriter.close(); close would cause ingestions - we want to avoid this as the new offsets won't commit
+            fileWriter.close(); // Not really needed -here for cleaner code
         } catch (IOException e) {
             log.error("Failed to rollback with exception={}", e);
         }
@@ -262,7 +262,7 @@ class TopicPartitionWriter {
         fileWriter.stop();
     }
 
-        static String getTempDirectoryName(String tempDirPath) {
+    static String getTempDirectoryName(String tempDirPath) {
         String tempDir = "kusto-sink-connector-" + UUID.randomUUID().toString();
         Path path = Paths.get(tempDirPath, tempDir);
 

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
@@ -243,7 +243,7 @@ class TopicPartitionWriter {
     void close() {
         try {
             fileWriter.rollback();
-            // fileWriter.close(); TODO ?
+            // fileWriter.close(); close would cause ingestions - we want to avoid this as the new offsets won't commit
         } catch (IOException e) {
             log.error("Failed to rollback with exception={}", e);
         }
@@ -261,7 +261,11 @@ class TopicPartitionWriter {
         }
     }
 
-    static String getTempDirectoryName(String tempDirPath) {
+    void stop() {
+        fileWriter.stop();
+    }
+
+        static String getTempDirectoryName(String tempDirPath) {
         String tempDir = "kusto-sink-connector-" + UUID.randomUUID().toString();
         Path path = Paths.get(tempDirPath, tempDir);
 

--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriter.java
@@ -239,7 +239,7 @@ class TopicPartitionWriter {
     void close() {
         try {
             fileWriter.rollback();
-            fileWriter.close(); // Not really needed -here for cleaner code
+            fileWriter.close();
         } catch (IOException e) {
             log.error("Failed to rollback with exception={}", e);
         }

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriterTest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriterTest.java
@@ -106,7 +106,7 @@ public class FileWriterTest {
         Assertions.assertEquals(1, Objects.requireNonNull(folder.listFiles()).length);
 
         // close current file
-        fileWriter.close();
+        fileWriter.stop();
         Assertions.assertEquals(5, files.size());
 
         List<Long> sortedFiles = new ArrayList<>(files.values());
@@ -142,7 +142,8 @@ public class FileWriterTest {
         Thread.sleep(1000);
 
         Assertions.assertEquals(0, files.size());
-        fileWriter.close();
+        fileWriter.rotate(10L);
+        fileWriter.stop();
         Assertions.assertEquals(1, files.size());
 
         String path2 = Paths.get(currentDirectory.getPath(), "testGzipFileWriter2_2").toString();
@@ -151,7 +152,7 @@ public class FileWriterTest {
         Assertions.assertTrue(mkdirs);
 
         Function<Long, String> generateFileName2 = (Long l) -> Paths.get(path2, java.util.UUID.randomUUID().toString()).toString();
-        // Expect one file to be ingested as flushInterval had changed
+        // Expect one file to be ingested as flushInterval had changed and is shorter than sleep time
         FileWriter fileWriter2 = new FileWriter(path2, MAX_FILE_SIZE, trackFiles, generateFileName2, 1000, new ReentrantReadWriteLock(), IngestionProperties.DATA_FORMAT.valueOf(ingestionProps.getDataFormat()), BehaviorOnError.FAIL);
 
         String msg2 = "Second Message";
@@ -164,10 +165,6 @@ public class FileWriterTest {
         List<Long> sortedFiles = new ArrayList<>(files.values());
         sortedFiles.sort((Long x, Long y) -> (int) (y - x));
         Assertions.assertEquals(sortedFiles, Arrays.asList((long) 15, (long) 8));
-
-        // make sure folder is clear once done
-        fileWriter2.close();
-        Assertions.assertEquals(0, Objects.requireNonNull(folder.listFiles()).length);
     }
 
     @Test
@@ -244,7 +241,7 @@ public class FileWriterTest {
         }});
 
         // make sure folder is clear once done
-        fileWriter2.close();
+        fileWriter2.stop();
         Assertions.assertEquals(0, Objects.requireNonNull(folder.listFiles()).length);
     }
 

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriterTest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/FileWriterTest.java
@@ -106,15 +106,15 @@ public class FileWriterTest {
         Assertions.assertEquals(1, Objects.requireNonNull(folder.listFiles()).length);
 
         // close current file
-        fileWriter.stop();
+        fileWriter.rotate(54L);
         Assertions.assertEquals(5, files.size());
 
         List<Long> sortedFiles = new ArrayList<>(files.values());
         sortedFiles.sort((Long x, Long y) -> (int) (y - x));
         Assertions.assertEquals(sortedFiles, Arrays.asList((long) 108, (long) 108, (long) 108, (long) 108, (long) 54));
 
-        // make sure folder is clear once done
-        Assertions.assertEquals(0, Objects.requireNonNull(folder.listFiles()).length);
+        // make sure folder is clear once done - with only the new file
+        Assertions.assertEquals(1, Objects.requireNonNull(folder.listFiles()).length);
     }
 
     @Test
@@ -165,6 +165,10 @@ public class FileWriterTest {
         List<Long> sortedFiles = new ArrayList<>(files.values());
         sortedFiles.sort((Long x, Long y) -> (int) (y - x));
         Assertions.assertEquals(sortedFiles, Arrays.asList((long) 15, (long) 8));
+
+        // make sure folder is clear once done
+        fileWriter2.close();
+        Assertions.assertEquals(1, Objects.requireNonNull(folder.listFiles()).length);
     }
 
     @Test

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTaskTest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTaskTest.java
@@ -160,11 +160,13 @@ public class KustoSinkTaskTest {
 
         doAnswer(answer).when(writerSpy).close();
         kustoSinkTaskSpy.open(tps);
+        writerSpy.open();
         tps.add(tp);
         kustoSinkTaskSpy.writers.put(tp, writerSpy);
 
         kustoSinkTaskSpy.close(tps);
         long l3 = System.currentTimeMillis();
+        System.out.println("l3-l2 " + (l3-l2));
         assertTrue(l3-l2 > sleepTime  && l3-l2 < sleepTime + 1000);
     }
 }

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTaskTest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTaskTest.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.kusto.kafka.connect.sink;
 
 import com.microsoft.azure.kusto.ingest.IngestClient;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -18,6 +19,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -168,5 +174,62 @@ public class KustoSinkTaskTest {
         long l3 = System.currentTimeMillis();
         System.out.println("l3-l2 " + (l3-l2));
         assertTrue(l3-l2 > sleepTime  && l3-l2 < sleepTime + 1000);
+    }
+
+    @Test
+    public void precommitDoesntCommitNewerOffsets() throws InterruptedException {
+        HashMap<String, String> configs = KustoSinkConnectorConfigTest.setupConfigs();
+        configs.put(KustoSinkConfig.KUSTO_SINK_FLUSH_INTERVAL_MS_CONF, "100");
+        KustoSinkTask kustoSinkTask = new KustoSinkTask();
+        KustoSinkTask kustoSinkTaskSpy = spy(kustoSinkTask);
+        doNothing().when(kustoSinkTaskSpy).validateTableMappings(Mockito.<KustoSinkConfig>any());
+        kustoSinkTaskSpy.start(configs);
+        ArrayList<TopicPartition> tps = new ArrayList<>();
+        TopicPartition topic1 = new TopicPartition("topic1", 1);
+        tps.add(topic1);
+        kustoSinkTaskSpy.open(tps);
+        TopicPartitionWriter topicPartitionWriter = kustoSinkTaskSpy.writers.get(topic1);
+        IngestClient mockedClient = mock(IngestClient.class);
+        TopicIngestionProperties props = new TopicIngestionProperties();
+        props.ingestionProperties = kustoSinkTaskSpy.getIngestionProps("topic1").ingestionProperties;
+        TopicPartitionWriter topicPartitionWriterSpy = spy(new TopicPartitionWriter(topic1, mockedClient, props, new KustoSinkConfig(configs), false, null, null));
+        topicPartitionWriterSpy.open();
+        kustoSinkTaskSpy.writers.put(topic1,topicPartitionWriterSpy);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        final Stopped stoppedObj = new Stopped();
+        AtomicInteger offset =  new AtomicInteger(1);
+        Runnable insertExec = () -> {
+            while (!stoppedObj.stopped) {
+                List<SinkRecord> records = new ArrayList<>();
+
+                records.add(new SinkRecord("topic1", 1, null, null, null, "stringy message".getBytes(StandardCharsets.UTF_8), offset.getAndIncrement()));
+                kustoSinkTaskSpy.put(new ArrayList<>(records));
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException ignore) {
+                }
+            }
+        };
+        Future<?> runner = executor.submit(insertExec);
+        Thread.sleep(500);
+        stoppedObj.stopped = true;
+        runner.cancel(true);
+        int current = offset.get();
+        HashMap<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        offsets.put(topic1, new OffsetAndMetadata(current));
+
+        Map<TopicPartition, OffsetAndMetadata> returnedOffsets = kustoSinkTaskSpy.preCommit(offsets);
+        kustoSinkTaskSpy.close(tps);
+
+        // Decrease one cause preCommit adds one
+        Assertions.assertEquals(returnedOffsets.get(topic1).offset() - 1,topicPartitionWriterSpy.lastCommittedOffset);
+        Thread.sleep(500);
+        // No ingestion occur even after waiting
+        Assertions.assertEquals(returnedOffsets.get(topic1).offset() - 1,topicPartitionWriterSpy.lastCommittedOffset);
+    }
+
+    static class Stopped {
+        boolean stopped;
     }
 }

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTaskTest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTaskTest.java
@@ -1,5 +1,6 @@
 package com.microsoft.azure.kusto.kafka.connect.sink;
 
+import com.microsoft.azure.kusto.ingest.IngestClient;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -36,7 +37,7 @@ public class KustoSinkTaskTest {
 
     @AfterEach
     public final void after() {
-        currentDirectory.delete();
+        boolean delete = currentDirectory.delete();
     }
 
     @Test

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTaskTest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTaskTest.java
@@ -48,8 +48,8 @@ public class KustoSinkTaskTest {
         kustoSinkTaskSpy.start(configs);
         ArrayList<TopicPartition> tps = new ArrayList<>();
         tps.add(new TopicPartition("topic1", 1));
-        tps.add(new TopicPartition("topic2", 2));
-        tps.add(new TopicPartition("topic3", 3));
+        tps.add(new TopicPartition("topic1", 2));
+        tps.add(new TopicPartition("topic2", 1));
 
         kustoSinkTaskSpy.open(tps);
 

--- a/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriterTest.java
+++ b/src/test/java/com/microsoft/azure/kusto/kafka/connect/sink/TopicPartitionWriterTest.java
@@ -266,13 +266,13 @@ public class TopicPartitionWriterTest {
         for (SinkRecord record : records) {
             spyWriter.writeRecord(record);
         }
-
         // 2 records are waiting to be ingested - expect close to revoke them so that even after 5 seconds it won't ingest
-        verifyZeroInteractions(mockClient);
+        Assertions.assertNull(spyWriter.lastCommittedOffset);
         spyWriter.close();
+        Assertions.assertNull(spyWriter.lastCommittedOffset);
+
         Thread.sleep(flushInterval + contextSwitchInterval);
-        verifyZeroInteractions(mockClient);
-        Assertions.assertEquals(null, spyWriter.lastCommittedOffset);
+        Assertions.assertNull(spyWriter.lastCommittedOffset);
     }
 
     private Map<String, String> getKustoConfigs(String basePath, long fileThreshold, long flushInterval) {


### PR DESCRIPTION
#### Pull Request Description
The sink task stop and close should first stop timers from ingesting anymore data so that we don't create duplicates when topic is opened again.
Resolving issue https://github.com/Azure/kafka-sink-azure-kusto/issues/69
---

**Fixes:**
- Possible duplicates on sink task stop
