### PR TITLE
Adding null check to handle rare NPE case

### DIFF
--- a/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
+++ b/src/main/java/com/microsoft/azure/kusto/kafka/connect/sink/KustoSinkTask.java
@@ -372,7 +372,10 @@ public class KustoSinkTask extends SinkTask {
         partitions.forEach((TopicPartition tp) -> writers.get(tp).stop());
         for (TopicPartition tp : partitions) {
             try {
-                writers.get(tp).close();
+                TopicPartitionWriter writer = writers.get(tp);
+                if (writer != null) {
+                    writer.close();
+                }
                 // TODO: if we still get duplicates from rebalance - consider keeping writers
                 // aside - we might
                 // just get the same topic partition again


### PR DESCRIPTION
#### Pull Request Description
In our deployment we rarely hit an NPE here, which typically results in duplicates due to the unhandled exception causing a premature exit from the `WorkerSinkTask.commitOffsets` method. In this failure mode we've already published batches to kusto, but we don't update the offsets due to an exception here.

I have not yet fully understood how we get into this state, where a TopicPartitionWriter doesn't exist for a TopicPartition.

#### Future Release Comment

Fixed the source of a NullPointerException that could result in duplicate records sent to Kusto.

**Breaking Changes:**

- None

**Features:**

- None

**Fixes:**

- None
