### PR TITLE
* Update to new SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,9 @@ the [Release History](README.md#16-release-history) section of this document.
 | 4.0.0           | 2023-03-07   | <ul><li>Upgrade Kusto Java SDK to 4.0.3 and Kafka Clients to 3.4.0</li><li>Disable table access validation at start up by default</li></ul>
 | 4.0.1           | 2023-03-26   | <ul><li>Upgrade Kusto Java SDK to 4.0.4</li></ul>
 | 4.0.2           | 2023-06-28   | <ul><li>Upgrade Kusto Java SDK to 5.0.0</li><li>Fix vulnerabilities in libs</li></ul>
+| 4.0.3           | 2023-07-23   | <ul><li>Upgrade Kusto Java SDK to 5.0.1</li><li>Fix vulnerabilities in libs</li></ul>
+| 4.0.4           | 2023-09-27   | <ul><li>Upgrade Kusto Java SDK to 5.0.2</li><li>Fix vulnerabilities in snappy-java</li></ul>
+
 ## 17. Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
     <description>A Kafka Connect plugin for Azure Data Explorer (Kusto) Database</description>
-    <version>4.0.3</version>
+    <version>4.0.4</version>
     <properties>
         <avro.random.generator.version>0.4.1</avro.random.generator.version>
         <awaitility.version>4.2.0</awaitility.version>
@@ -24,18 +24,18 @@
         <jsonsmart.version>2.4.10</jsonsmart.version>
         <junit.version>5.10.0</junit.version>
         <kafka.connect.avro.converter.version>7.4.1</kafka.connect.avro.converter.version>
-        <kafka.version>3.5.0</kafka.version>
-        <kusto.sdk.version>5.0.1</kusto.sdk.version>
+        <kafka.version>3.5.1</kafka.version>
+        <kusto.sdk.version>5.0.2</kusto.sdk.version>
         <mvn.assembly.plugin.version>3.2.0</mvn.assembly.plugin.version>
         <mvn.compiler.plugin.version>3.11.0</mvn.compiler.plugin.version>
         <mvn.failsafe.plugin.version>3.0.0</mvn.failsafe.plugin.version>
         <mvn.surefire.plugin.version>3.0.0</mvn.surefire.plugin.version>
         <mockito.version>4.11.0</mockito.version>
         <!-- Added to override vulnerable deps -->
-        <netty.version>4.1.94.Final</netty.version>
+        <netty.version>4.1.98.Final</netty.version>
         <nimbusjose.jwt.version>9.31</nimbusjose.jwt.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <snappy.version>1.1.10.3</snappy.version>
+        <snappy.version>1.1.10.4</snappy.version>
         <testcontainer.version>1.18.3</testcontainer.version>
     </properties>
     <build>


### PR DESCRIPTION
* Update Java SDK to 5.0.2
* Update XERIAL snappy to address CVE