### PR TITLE
fix: bump Netty to 4.1.133.Final to remediate netty CVEs (CVE-2026-42578/79/80/81/83/84/85/87, CVE-2026-41417)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <kusto.shade.prefix>kusto_kafka_connector_shaded</kusto.shade.prefix>
         <!-- Netty version to resolve conflicts -->
         <jackson.version>2.21.1</jackson.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Summary

Bumps `netty.version` from `4.1.132.Final` to `4.1.133.Final` on the 4.1.x line (the project intentionally pins 4.1.x via `netty-bom` — see comment in `pom.xml`: *Force Netty 4.1.x to avoid conflicts with 4.2.x*).

## Vulnerabilities remediated

Reported against v5.3.0 at netty 4.1.132.Final:

| CVE | Component | Severity |
|---|---|---|
| CVE-2026-42583 | netty-codec | HIGH (7.5) |
| CVE-2026-42579 | netty-codec-dns | HIGH (7.5) |
| CVE-2026-42584 | netty-codec-http | HIGH (7.3) |
| CVE-2026-42587 | netty-codec-http / netty-codec-http2 | HIGH (7.5) |
| CVE-2026-41417 | netty-codec-http | MEDIUM (5.3) |
| CVE-2026-42580 | netty-codec-http | MEDIUM (6.5) |
| CVE-2026-42581 | netty-codec-http | MEDIUM (5.8) |
| CVE-2026-42585 | netty-codec-http | MEDIUM (6.5) |
| CVE-2026-42578 | netty-handler-proxy | LOW |

All have a fix version of `4.1.133.Final` on the 4.1.x line.

## Relationship to #175

Dependabot PR #175 proposes `4.2.12.Final → 4.2.13.Final`, but that PR was opened before #159 deliberately pinned the project back to the 4.1.x line. Bumping to 4.2.x re-introduces the conflict #159 was designed to avoid. Closing #175 in favor of this 4.1.x bump.

## Validation

- `mvn dependency:tree -Dincludes=io.netty` confirms all `io.netty:*` artifacts (codec, codec-http, codec-http2, codec-dns, handler-proxy, etc.) resolve to `4.1.133.Final`.
- `mvn -DskipTests package` succeeds.