### PR TITLE
fix: bump Netty to 4.2.13.Final to remediate netty CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,11 @@
         <kusto.shade.prefix>kusto_kafka_connector_shaded</kusto.shade.prefix>
         <!-- Netty version to resolve conflicts -->
         <jackson.version>2.21.1</jackson.version>
-        <netty.version>4.2.12.Final</netty.version>
+        <netty.version>4.2.13.Final</netty.version>
     </properties>
     <dependencyManagement>
         <dependencies>
-            <!-- Force Netty 4.1.x to avoid conflicts with 4.2.x -->
+            <!-- Pin netty-bom to ${netty.version} so all io.netty:* modules resolve to the same release -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>


### PR DESCRIPTION
## Summary

Bumps `netty.version` from `4.2.12.Final` to `4.2.13.Final` via the `io.netty:netty-bom` import.

## Vulnerabilities remediated

Reported against v5.3.0 (originally at 4.1.132.Final, currently 4.2.12.Final on master):

| CVE | Component | Severity |
|---|---|---|
| CVE-2026-42583 | netty-codec | HIGH (7.5) |
| CVE-2026-42579 | netty-codec-dns | HIGH (7.5) |
| CVE-2026-42584 | netty-codec-http | HIGH (7.3) |
| CVE-2026-42587 | netty-codec-http / netty-codec-http2 | HIGH (7.5) |
| CVE-2026-41417 | netty-codec-http | MEDIUM (5.3) |
| CVE-2026-42580 | netty-codec-http | MEDIUM (6.5) |
| CVE-2026-42581 | netty-codec-http | MEDIUM (5.8) |
| CVE-2026-42585 | netty-codec-http | MEDIUM (6.5) |
| CVE-2026-42578 | netty-handler-proxy | LOW |

All are fixed in `4.2.13.Final` (and `4.1.133.Final` on the 4.1.x line).

## Context

- The previous "Force Netty 4.1.x to avoid conflicts with 4.2.x" pin (#159) was relaxed in #167, which bumped master to `4.2.12.Final`. This PR continues on the 4.2.x line.
- Replaces closed PRs #175 (became stale) and #180 (built against the prior 4.1.x state).
- Stale comment `Force Netty 4.1.x to avoid conflicts with 4.2.x` removed.

## Validation

- `mvn dependency:tree -Dincludes=io.netty` shows all `io.netty:*` artifacts (codec, codec-http, codec-http2, codec-dns, handler-proxy, resolver-dns, transport-native-epoll/kqueue, etc.) resolve to `4.2.13.Final`.
- `mvn -DskipTests package` succeeds.