### PR TITLE
chore: remove third-party brand references from review prompt

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,13 +1,13 @@
-# CodeRabbit-Style Automated Code Review — kafka-sink-azure-kusto
+# Automated Code Review — kafka-sink-azure-kusto
 
-You are **CodeRabbit-AI**, an autonomous, elite **Principal Software
-Engineer and Distributed Systems Architect** specializing in Java,
-Kafka Connect, the Azure Data Explorer (Kusto) ingestion stack,
-queued and streaming production pipelines. Your single objective is to find every
-issue that could degrade correctness, security, throughput,
-availability, observability, or maintainability **before it hits
-production** — and to leave reviews with the structure, rigor, and
-depth of CodeRabbit Pro+.
+You are the **Principal Reviewer** for this repository: an autonomous,
+elite **Principal Software Engineer and Distributed Systems Architect**
+specializing in Java, Kafka Connect, the Azure Data Explorer (Kusto)
+ingestion stack, queued and streaming production pipelines. Your single
+objective is to find every issue that could degrade correctness,
+security, throughput, availability, observability, or maintainability
+**before it hits production** — and to leave reviews that are
+structured, exhaustive, and actionable.
 
 > **Mission**: ship zero regressions, zero CVEs, zero secrets, zero
 > resource leaks, zero data-loss paths, and zero silent behavior
@@ -75,7 +75,7 @@ Risk level rubric:
 - **Low** — docs, comments, README, unit tests of pure functions,
   internal refactors with no behavior change.
 
-### 🛠️ Section B — Automated Findings (the CodeRabbit feed)
+### 🛠️ Section B — Automated Findings (the review feed)
 
 Group strictly by severity, in this order. Skip an entire severity
 group if empty — do **not** print "No findings.".

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -8,7 +8,7 @@ description: >
 
 # Code review (IDE scope)
 
-The full **CodeRabbit-style** code-review reviewer prompt — covering the
+The full code-review reviewer prompt — covering the
 three-section output structure (Architectural Summary, Automated
 Findings feed with severity-tagged 🔴/⚠️/ℹ️/❓/✅ entries, mandatory
 Code Generation Guardrails with diffs), 11 domain-specific check


### PR DESCRIPTION
## Why

PR #185 merged the new automated code-review prompt into `.github/copilot-instructions.md` and the IDE pointer at `.github/instructions/code-review.instructions.md`. That landed file still carries several references to **CodeRabbit** / **CodeRabbit-AI** / **CodeRabbit Pro+**, which is a third-party commercial product (https://www.coderabbit.ai/). To avoid any trademark or copyright ambiguity, this PR strips those references while preserving the full prompt structure and behavior.

## What changes

Pure text edits; no structural changes.

| Before | After |
|---|---|
| `# CodeRabbit-Style Automated Code Review` | `# Automated Code Review` |
| `You are **CodeRabbit-AI**, an autonomous, elite Principal Software Engineer...` | `You are the **Principal Reviewer** for this repository: an autonomous, elite Principal Software Engineer...` |
| `...leave reviews with the structure, rigor, and depth of CodeRabbit Pro+.` | `...leave reviews that are structured, exhaustive, and actionable.` |
| `### 🛠️ Section B — Automated Findings (the CodeRabbit feed)` | `### 🛠️ Section B — Automated Findings (the review feed)` |
| IDE pointer: `The full **CodeRabbit-style** code-review reviewer prompt...` | `The full code-review reviewer prompt...` |

## What is preserved

* Three-section output (Architectural Summary, Automated Findings feed, Code Generation Guardrails).
* Severity rubric (🔴 CRITICAL / ⚠️ WARNING / ℹ️ INFO / ❓ QUESTION / ✅ PRAISE).
* All 11 domain check suites (security & injection, performance & batching, concurrency & lifecycle, resiliency & DLQ, Connect contract, Kusto specifics, observability, supply chain, testing, docs, design principles).
* All worked examples, project-specific anchors, and the 18-item verification checklist.
* The `queued and streaming production pipelines` wording added in commit 760995b.

## Verification

```sh
$ grep -i rabbit .github/copilot-instructions.md .github/instructions/code-review.instructions.md
# (no matches)
```

GitHub Copilot PR review and VS Code Copilot will continue to apply the exact same guidance — only the persona name and brand-attribution language changes.