### PR TITLE
fix: update kusto-data to 7.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <commoncodec.version>1.20.0</commoncodec.version>
         <commonio.version>2.21.0</commonio.version>
         <json.smart.version>2.6.0</json.smart.version>
-        <kusto.sdk.version>7.0.5</kusto.sdk.version>
+        <kusto.sdk.version>7.0.8</kusto.sdk.version>
         <kafka.version>4.1.1</kafka.version>
         <reactor.netty.version>1.3.2</reactor.netty.version>
         <!-- Test dependencies -->


### PR DESCRIPTION
#### Pull Request Description
issue-ticket:
https://github.com/Azure/kafka-sink-azure-kusto/issues/187

There is a known issue in azure-core involving the SharedExecutorService.
The solution requires a library-level update: starting with azure-core 1.54.0, Microsoft revised the SharedExecutorService and added a queue capacity to prevent this problem.

This MR just an update of kusto-data to a version with a fix for azure-core.

---

#### Future Release Comment

update kusto-data from 7.0.5 to 7.0.8. Within this change azure-core is updated from 1.52.0 to 1.57.1 

**Breaking Changes:**

- None

**Features:**

- None

**Fixes:**

- None
