### PR TITLE
fix: pin Jackson to 2.21.4 to remediate jackson-databind CVEs (5.3.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,7 @@ the [Release History](README.md#17-release-history) section of this document.
 | 5.3.0           | 2026-04-27   | <ul><li>Add wildcard (`*`) topic-to-table mapping support in `kusto.tables.topics.mapping` to provide a default ingestion configuration for topics that are not explicitly mapped</li></ul> |
 | 5.3.1           | 2026-05-20   | <ul><li>Security fix: Bump Netty to 4.2.13.Final to remediate CVE-2026-42583, CVE-2026-42579, CVE-2026-42584, CVE-2026-42587, CVE-2026-41417, CVE-2026-42580, CVE-2026-42581, CVE-2026-42585, and CVE-2026-42578</li></ul> |
 | 5.3.2           | 2026-06-15   | <ul><li>Security fix: Bump Netty to 4.2.15.Final to remediate CVE-2026-47244, CVE-2026-48043, CVE-2026-44249, CVE-2026-45416, CVE-2026-45674, CVE-2026-47691, CVE-2026-45673, and CVE-2026-45536</li></ul> |
+| 5.3.3           | 2026-07-01   | <ul><li>Security fix: Pin Jackson to 2.21.4 (via jackson-bom) to remediate CVE-2026-54512, CVE-2026-54513, and CVE-2026-54514 in jackson-databind, and align databind/annotations (previously 2.16.0) with jackson-core</li></ul> |
 
 ## 18. Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
     <description>A Kafka Connect plugin for Azure Data Explorer (Kusto) Database</description>
-    <version>5.3.2</version>
+    <version>5.3.3</version>
     <properties>
         <!-- Compile dependencies -->
         <az.core.version>1.57.0</az.core.version>
@@ -48,7 +48,12 @@
         <maven.shade.plugin.version>3.6.0</maven.shade.plugin.version>
         <kusto.shade.prefix>kusto_kafka_connector_shaded</kusto.shade.prefix>
         <!-- Netty version to resolve conflicts -->
-        <jackson.version>2.21.1</jackson.version>
+        <!-- Bumped 2026-07-01: jackson-bom 2.21.4 remediates CVE-2026-54512, CVE-2026-54513 (HIGH,
+             PolymorphicTypeValidator bypasses) and CVE-2026-54514 (InetSocketAddress eager DNS), and aligns
+             jackson-databind/annotations (previously 2.16.0) with jackson-core. CVE-2026-54515 (MEDIUM) is
+             fixed only in 2.21.5/2.18.9 (not yet published) or Jackson 3.1.4; bump to 2.21.5 when released.
+             See https://github.com/FasterXML/jackson-databind/security/advisories -->
+        <jackson.version>2.21.4</jackson.version>
         <!-- Bumped 2026-06-15: 4.2.15.Final remediates CVE-2026-47244, CVE-2026-48043 (netty-codec-http2),
              CVE-2026-44249, CVE-2026-45416 (netty-handler), CVE-2026-45674, CVE-2026-47691, CVE-2026-45673
              (netty-resolver-dns) and CVE-2026-45536 (netty-transport-native-epoll/kqueue).
@@ -62,6 +67,15 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Pin jackson-bom to ${jackson.version} so all com.fasterxml.jackson:* modules (databind,
+                 annotations, core, datatype) resolve to the same patched release -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
         <!-- Shade plugin -->
         <maven.shade.plugin.version>3.6.0</maven.shade.plugin.version>
         <kusto.shade.prefix>kusto_kafka_connector_shaded</kusto.shade.prefix>
-        <!-- Netty version to resolve conflicts -->
         <!-- Bumped 2026-07-01: jackson-bom 2.21.4 remediates CVE-2026-54512, CVE-2026-54513 (HIGH,
              PolymorphicTypeValidator bypasses) and CVE-2026-54514 (InetSocketAddress eager DNS), and aligns
              jackson-databind/annotations (previously 2.16.0) with jackson-core. CVE-2026-54515 (MEDIUM) is
@@ -70,8 +69,8 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Pin jackson-bom to ${jackson.version} so all com.fasterxml.jackson:* modules (databind,
-                 annotations, core, datatype) resolve to the same patched release -->
+            <!-- Pin jackson-bom to ${jackson.version} so all com.fasterxml.jackson.* modules (core,
+                 databind, annotations, datatype) resolve to the same patched release -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>


### PR DESCRIPTION
## Summary

Security fix for **jackson-databind** flagged in the partner (Confluent Hub) scan of connector **5.3.2**. `jackson-databind` was resolving transitively to **2.16.0** (mismatched with `jackson-core` 2.21.1). This PR imports `jackson-bom` and bumps `jackson.version` `2.21.1 → 2.21.4`, aligning every `com.fasterxml.jackson` module to a single patched release.

## CVEs remediated (verified with Trivy / Aqua DB — same source as the partner report)

| CVE | Severity | CVSS | 2.16.0 | 2.21.4 |
| --- | --- | --- | --- | --- |
| CVE-2026-54512 (PTV generic-parameter bypass) | HIGH | 8.1 | present | **cleared** |
| CVE-2026-54513 (PTV array-component bypass) | HIGH | 8.1 | present | **cleared** |
| CVE-2026-54514 (InetSocketAddress eager DNS) | MEDIUM | 5.3 | present | **cleared** |

## Known follow-up

- **CVE-2026-54515** (MEDIUM, 5.3) is fixed only in **2.21.5 / 2.18.9** (not yet published to Maven Central — latest are 2.21.4 / 2.18.8) or **Jackson 3.1.4** (major release under the new `tools.jackson` groupId, breaking package renames — out of scope for a security patch). Tracked for a follow-up bump `2.21.4 → 2.21.5` once released.

## Changes

- `pom.xml`: import `jackson-bom`, bump `jackson.version` to `2.21.4`, connector version `5.3.2 → 5.3.3`.
- `README.md`: release-history row for 5.3.3.

## Validation

- Dependency tree: all `com.fasterxml.jackson.core:*` resolve to 2.21.4, **zero 2.16.0 remnants**.
- Uber jar: bundled `jackson-databind` = 2.21.4 (verified via `pom.properties`).
- Unit tests: **127/127 pass** (JDK 17).
- Trivy before/after scan confirms the three CVEs above are cleared.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>