### PR TITLE
fix: bump Jackson to 2.21.5 to remediate CVE-2026-54515 (5.3.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,6 +807,7 @@ the [Release History](README.md#17-release-history) section of this document.
 | 5.3.1           | 2026-05-20   | <ul><li>Security fix: Bump Netty to 4.2.13.Final to remediate CVE-2026-42583, CVE-2026-42579, CVE-2026-42584, CVE-2026-42587, CVE-2026-41417, CVE-2026-42580, CVE-2026-42581, CVE-2026-42585, and CVE-2026-42578</li></ul> |
 | 5.3.2           | 2026-06-15   | <ul><li>Security fix: Bump Netty to 4.2.15.Final to remediate CVE-2026-47244, CVE-2026-48043, CVE-2026-44249, CVE-2026-45416, CVE-2026-45674, CVE-2026-47691, CVE-2026-45673, and CVE-2026-45536</li></ul> |
 | 5.3.3           | 2026-07-01   | <ul><li>Security fix: Pin Jackson to 2.21.4 (via jackson-bom) to remediate CVE-2026-54512, CVE-2026-54513, and CVE-2026-54514 in jackson-databind, and align databind/annotations (previously 2.16.0) with jackson-core</li></ul> |
+| 5.3.4           | 2026-07-07   | <ul><li>Security fix: Bump Jackson to 2.21.5 (via jackson-bom) to remediate CVE-2026-54515 in jackson-databind</li></ul> |
 
 ## 18. Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
     <description>A Kafka Connect plugin for Azure Data Explorer (Kusto) Database</description>
-    <version>5.3.3</version>
+    <version>5.3.4</version>
     <properties>
         <!-- Compile dependencies -->
         <az.core.version>1.57.0</az.core.version>
@@ -47,12 +47,12 @@
         <!-- Shade plugin -->
         <maven.shade.plugin.version>3.6.0</maven.shade.plugin.version>
         <kusto.shade.prefix>kusto_kafka_connector_shaded</kusto.shade.prefix>
-        <!-- Bumped 2026-07-01: jackson-bom 2.21.4 remediates CVE-2026-54512, CVE-2026-54513 (HIGH,
-             PolymorphicTypeValidator bypasses) and CVE-2026-54514 (InetSocketAddress eager DNS), and aligns
-             jackson-databind/annotations (previously 2.16.0) with jackson-core. CVE-2026-54515 (MEDIUM) is
-             fixed only in 2.21.5/2.18.9 (not yet published) or Jackson 3.1.4; bump to 2.21.5 when released.
+        <!-- Bumped 2026-07-07: jackson-bom 2.21.5 remediates CVE-2026-54515 (@JsonIgnoreProperties bypass
+             under ACCEPT_CASE_INSENSITIVE_PROPERTIES). 2.21.4 previously remediated CVE-2026-54512,
+             CVE-2026-54513 (HIGH, PolymorphicTypeValidator bypasses) and CVE-2026-54514 (InetSocketAddress
+             eager DNS), and aligned jackson-databind/annotations (previously 2.16.0) with jackson-core.
              See https://github.com/FasterXML/jackson-databind/security/advisories -->
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
         <!-- Bumped 2026-06-15: 4.2.15.Final remediates CVE-2026-47244, CVE-2026-48043 (netty-codec-http2),
              CVE-2026-44249, CVE-2026-45416 (netty-handler), CVE-2026-45674, CVE-2026-47691, CVE-2026-45673
              (netty-resolver-dns) and CVE-2026-45536 (netty-transport-native-epoll/kqueue).


### PR DESCRIPTION
## Summary

Remediates **CVE-2026-54515** (MEDIUM, CVSS 5.3, CWE-915) in `jackson-databind`, re-flagged by the partner Confluent Hub scan against connector **5.3.3** (which shipped `jackson-databind` 2.21.4).

`jackson-databind` **2.21.5** was published to Maven Central on **2026-07-07** and fixes this CVE. This is a one-line bump of `jackson.version`, propagated to every jackson module via the imported `jackson-bom`.

## Why this was open until now

In 5.3.3 we pinned Jackson to 2.21.4, which cleared CVE-2026-54512/54513/54514 but not 54515 — the latter's fix (2.18.9 / 2.21.5 / 2.22.1 / 3.1.4) was not yet published upstream. 2.21.5 has now released, so the fix is a simple version bump.

## CVE

| CVE | Severity | CVSS | 2.21.4 (5.3.3) | 2.21.5 (this PR) |
| --- | --- | --- | --- | --- |
| CVE-2026-54515 (`@JsonIgnoreProperties` bypass under `ACCEPT_CASE_INSENSITIVE_PROPERTIES`) | MEDIUM | 5.3 | present | **cleared** |

References: [GHSA-5jmj-h7xm-6q6v](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-5jmj-h7xm-6q6v), fix commit 0e1b0b2 (PR FasterXML/jackson-databind#5964).

## Changes

- `pom.xml`: `jackson.version` 2.21.4 to 2.21.5; connector version 5.3.3 to 5.3.4.
- `README.md`: release-history row for 5.3.4.

## Validation

- Dependency tree: all `com.fasterxml.jackson.core:*` resolve to 2.21.5, **zero 2.21.4 remnants** (`jackson-annotations` is 2.21 by Jackson's own BOM design).
- Shipped uber jar + Confluent zip bundle `jackson-databind-2.21.5.jar`.
- **Trivy scan of the shipped jar: zero CVEs (CVE-2026-54515 cleared).**
- Unit tests: **127/127 pass** (JDK 17).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
