### PR TITLE
Upgrade Netty to 4.2.17.Final for CVE-2026-59903

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ the [Release History](README.md#17-release-history) section of this document.
 | 5.3.3           | 2026-07-01   | <ul><li>Security fix: Pin Jackson to 2.21.4 (via jackson-bom) to remediate CVE-2026-54512, CVE-2026-54513, and CVE-2026-54514 in jackson-databind, and align databind/annotations (previously 2.16.0) with jackson-core</li></ul> |
 | 5.3.4           | 2026-07-07   | <ul><li>Security fix: Bump Jackson to 2.21.5 (via jackson-bom) to remediate CVE-2026-54515 in jackson-databind</li></ul> |
 | 5.3.5           | 2026-08-04   | <ul><li>Security fix: Bump io.netty:netty-bom from 4.2.15.Final to 4.2.16.Final in the netty group</li></ul> |
+| 5.3.6           | 2026-08-25   | <ul><li>Security fix: Bump io.netty:netty-bom from 4.2.16.Final to 4.2.17.Final to remediate CVE-2026-59903 in netty-codec-http</li></ul> |
 
 ## 18. Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>kafka-sink-azure-kusto</artifactId>
     <packaging>jar</packaging>
     <description>A Kafka Connect plugin for Azure Data Explorer (Kusto) Database</description>
-    <version>5.3.5</version>
+    <version>5.3.6</version>
     <properties>
         <!-- Compile dependencies -->
         <az.core.version>1.57.0</az.core.version>
@@ -53,12 +53,13 @@
              eager DNS), and aligned jackson-databind/annotations (previously 2.16.0) with jackson-core.
              See https://github.com/FasterXML/jackson-databind/security/advisories -->
         <jackson.version>2.21.5</jackson.version>
-        <!-- Bumped 2026-08-04: netty-bom 4.2.16.Final remediates multiple HIGH-severity Netty CVEs,
-             including DoS, memory-exhaustion, memory-leak, HTTP/HTTP2/HTTP3 parsing, HAProxy, STOMP, Redis
-             and XML codec vulnerabilities (CVE-2026-44891, CVE-2026-55831, CVE-2026-55833, CVE-2026-55851,
-             CVE-2026-56745, CVE-2026-56816, CVE-2026-56817, CVE-2026-56818, CVE-2026-56819, CVE-2026-59899,
-             CVE-2026-59900 and CVE-2026-59901). See https://github.com/netty/netty/security/advisories -->
-        <netty.version>4.2.16.Final</netty.version>
+        <!-- Bumped 2026-08-24: netty-bom 4.2.17.Final remediates CVE-2026-59903 (CorsHandler can
+             overwrite application Vary headers). 4.2.16.Final previously remediated multiple
+             HIGH-severity Netty CVEs, including CVE-2026-44891, CVE-2026-55831, CVE-2026-55833,
+             CVE-2026-55851, CVE-2026-56745, CVE-2026-56816, CVE-2026-56817, CVE-2026-56818,
+             CVE-2026-56819, CVE-2026-59899, CVE-2026-59900 and CVE-2026-59901.
+             See https://github.com/netty/netty/security/advisories -->
+        <netty.version>4.2.17.Final</netty.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Summary

- upgrade the Netty BOM from 4.2.16.Final to 4.2.17.Final
- remediate CVE-2026-59903 in netty-codec-http
- bump the connector version to 5.3.6
- update the README release history

## Validation

- resolved io.netty:netty-codec-http version: 4.2.17.Final
- 127 unit tests passed
- E2E tests executed against the Kusto test environment
- Maven POM and README formatting validated